### PR TITLE
Add option to read env variable for default namespace on activation

### DIFF
--- a/packages/cli/src/credentials/K8sCredentialManager.ts
+++ b/packages/cli/src/credentials/K8sCredentialManager.ts
@@ -205,7 +205,6 @@ class K8sCredentialManager extends AbstractCredentialManager {
             const kc: any = new k8s.KubeConfig();
             kc.loadFromDefault();
 
-            // Check for $WORKSPACE_NAMESPACE or $DEVWORKSPACE_NAMESPACE
             const currentContext = kc.getContextObject(kc.getCurrentContext());
             if (!currentContext) {
                 throw new Error("Current context was not found");
@@ -216,12 +215,12 @@ class K8sCredentialManager extends AbstractCredentialManager {
             }
             let k8sNamespace;
             if (
-                process.env.WORKSPACE_NAMESPACE ||
-                process.env.DEVWORKSPACE_NAMESPACE
+                process.env.DEVWORKSPACE_NAMESPACE ||
+                process.env.WORKSPACE_NAMESPACE
             ) {
                 k8sNamespace =
-                    process.env.WORKSPACE_NAMESPACE ||
-                    process.env.DEVWORKSPACE_NAMESPACE;
+                    process.env.DEVWORKSPACE_NAMESPACE ||
+                    process.env.WORKSPACE_NAMESPACE;
             } else {
                 k8sNamespace = currentContext.namespace
                     ? currentContext.namespace

--- a/packages/cli/src/credentials/K8sCredentialManager.ts
+++ b/packages/cli/src/credentials/K8sCredentialManager.ts
@@ -205,6 +205,7 @@ class K8sCredentialManager extends AbstractCredentialManager {
             const kc: any = new k8s.KubeConfig();
             kc.loadFromDefault();
 
+            // Check for $WORKSPACE_NAMESPACE or $DEVWORKSPACE_NAMESPACE
             const currentContext = kc.getContextObject(kc.getCurrentContext());
             if (!currentContext) {
                 throw new Error("Current context was not found");
@@ -213,9 +214,19 @@ class K8sCredentialManager extends AbstractCredentialManager {
             if (!currentUser) {
                 throw new Error("Current user was not found");
             }
-            const k8sNamespace = currentContext.namespace
-                ? currentContext.namespace
-                : currentContext.name?.split("/")[0];
+            let k8sNamespace;
+            if (
+                process.env.WORKSPACE_NAMESPACE ||
+                process.env.DEVWORKSPACE_NAMESPACE
+            ) {
+                k8sNamespace =
+                    process.env.WORKSPACE_NAMESPACE ||
+                    process.env.DEVWORKSPACE_NAMESPACE;
+            } else {
+                k8sNamespace = currentContext.namespace
+                    ? currentContext.namespace
+                    : currentContext.name?.split("/")[0];
+            }
             if (!k8sNamespace) {
                 throw new Error("Namespace was not defined");
             }


### PR DESCRIPTION
Potentially resolves #9 

This PR adds a simple change to the way we originally handled loading the initial workspace where the secrets are stored in the credential manager plugin. With this change, if an environment variable of `$WORKSPACE_NAMESPACE` or `$DEVWORKSPACE_NAMESPACE` is present, then the credential plugin will set the default namespace to be of that environment variable.