### PR TITLE
Remove prepublish script breaking release action

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,6 @@
         "lint:tests": "eslint \"**/__tests__/**/*.ts\"",
         "prebuild": "npm run clean && npm run lint && echo Using TypeScript && tsc --version",
         "build": "tsc --pretty && npm run checkTestsCompile && npm run circularDependencyCheck",
-        "prepublishOnly": "npm run build && bash ./scripts/bundleKeytar.sh",
         "watch": "tsc --pretty --watch",
         "watch:test": "jest --watch",
         "installPlugin": "npm install && npm run clean && npm run build && zowe plugins install .",


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Remove `prepublish` script referencing keytar script that broke the release action.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->