### PR TITLE
fix: Update package.json to include ZE as ext. dependency

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -18,6 +18,9 @@
     "engines": {
         "vscode": "^1.63.2"
     },
+    "extensionDependencies": [
+        "Zowe.vscode-extension-for-zowe"
+    ],
     "scripts": {
         "build": "tsup",
         "dev": "npm run build -- --watch",


### PR DESCRIPTION
**What It Does**

Fixes an issue where the K8s Secrets for ZE package does not specify Zowe Explorer as a dependency.
This means you can install it without having Zowe Explorer installed... but this seems unintentional as you cannot use the extension without ZE 😅 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->