### PR TITLE
chore: pin actions to SHA sums

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Use Node.js LTS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: lts/*
 

--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -9,10 +9,10 @@ jobs:
     name: Process Label Action
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Process Label Action
-        uses: hramos/respond-to-issue-based-on-label@v2
+        uses: hramos/respond-to-issue-based-on-label@a366dfe725db739c4522391dd1cb3daa9cb399d5 # v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: '.github/label-actions.yml'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,13 +12,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 
     - name: Check Changelog Updated
       id: checkchangelogupdated
-      uses: awharn/check_changelog_action@v1
+      uses: awharn/check_changelog_action@c55576539feda35872002e76b03da4e61cc4fed7 # v1
       with:
         header: "## TBD Release"
         file: "CHANGELOG.md"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/resources/codeql-config.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Use Node.js LTS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: lts/*
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
         with:
           # General rules applied to both, issues and pull requests (PRs)
           start-date: "2022-07-30T00:00:00Z"

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -20,14 +20,14 @@ jobs:
     name: Move project item
     runs-on: ubuntu-latest
     steps:
-    - uses: zowe-actions/shared-actions/project-move-item@main
+    - uses: zowe-actions/shared-actions/project-move-item@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
       if: ${{ github.event.issue && fromJSON(env.ISSUE_STATUSES)[github.event.label.name] }}
       with:
         item-status: ${{ fromJSON(env.ISSUE_STATUSES)[github.event.label.name] }}
         project-number: ${{ env.PROJECT_NUMBER }}
         project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
 
-    - uses: zowe-actions/shared-actions/project-move-item@main
+    - uses: zowe-actions/shared-actions/project-move-item@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
       if: ${{ github.event.pull_request }}
       with:
         assign-author: true

--- a/.github/workflows/zowe-cli-plugin.yml
+++ b/.github/workflows/zowe-cli-plugin.yml
@@ -28,10 +28,10 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: ${{ matrix.node-version }}
 
@@ -45,7 +45,7 @@ jobs:
 
             - name: Update Dependencies
               id: npm-update
-              uses: zowe-actions/octorelease/script@v1
+              uses: zowe-actions/octorelease/script@e0672bf28f74f36219713afe75915ea2dc7bf85b # v1
               with:
                   script: npmUpdate
 
@@ -60,7 +60,7 @@ jobs:
             - name: Start K3s Cluster
               id: k3s
               if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest' }}
-              uses: self-actuated/setup-k3sup@v1
+              uses: self-actuated/setup-k3sup@a1df32201f1b8868cd7a665afb09ff92446a87b3 # v1
 
             - name: Create System Test Properties
               if: ${{ always() && steps.k3s.outcome == 'success' }}
@@ -77,14 +77,14 @@ jobs:
 
             - name: Archive Results
               if: ${{ always() && steps.build.outcome == 'success' }}
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                   name: ${{ matrix.os }}-${{ matrix.node-version }}-results
                   path: packages/cli/__tests__/__results__/
 
             - name: Upload Results to Codecov
               if: ${{ always() && steps.build.outcome == 'success' }}
-              uses: codecov/codecov-action@v3
+              uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
               with:
                   env_vars: OS,NODE
 
@@ -99,14 +99,14 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               with:
                   fetch-depth: 0
                   persist-credentials: false
                   ref: ${{ github.ref }}
 
             - name: Use Node.js LTS
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: "lts/*"
 
@@ -117,7 +117,7 @@ jobs:
               run: npm install -g lerna@6
 
             - name: Update Dependencies
-              uses: zowe-actions/octorelease/script@v1
+              uses: zowe-actions/octorelease/script@e0672bf28f74f36219713afe75915ea2dc7bf85b # v1
               env:
                   GIT_COMMITTER_NAME: ${{ secrets.ZOWE_ROBOT_USER }}
                   GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}
@@ -128,7 +128,7 @@ jobs:
             - name: Build Source
               run: npm run build
 
-            - uses: zowe-actions/octorelease@v1
+            - uses: zowe-actions/octorelease@e0672bf28f74f36219713afe75915ea2dc7bf85b # v1
               env:
                   GIT_COMMITTER_NAME: ${{ secrets.ZOWE_ROBOT_USER }}
                   GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}


### PR DESCRIPTION
**What It Does**

Pins all workflow actions to their equivalent SHA sums (based on previous "at-tags").

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)